### PR TITLE
fixed issue where strikes could not be reset

### DIFF
--- a/baseballinator.py
+++ b/baseballinator.py
@@ -131,7 +131,7 @@ def main_menu():
         print("The balls have been reset to 0!")
         main_menu()
     elif str(choice) == "8":
-        txt = Path("./strikes")
+        txt = Path("./strikes.txt")
         reset_num(txt)
         print("The strikes have been reset to 0!")
         main_menu()


### PR DESCRIPTION
Just a missing '.txt' after a file name. Created an extra file when score was reset, preventing the strikes from ever reverting to zero. 

(My first pull request! Hello, World?)
